### PR TITLE
Improve hero layout and add fire animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -80,3 +80,18 @@
     @apply bg-background text-foreground;
   }
 }
+@layer components {
+  .fire-underline {
+    @apply relative inline-block pb-1;
+  }
+  .fire-underline::after {
+    content: '';
+    @apply absolute left-0 right-0 bottom-0 h-1 rounded-md;
+    background: linear-gradient(to top, #ff914d, transparent);
+    animation: flame 1s infinite ease-in-out;
+  }
+}
+@keyframes flame {
+  0%, 100% { transform: translateY(0) scaleY(1); opacity: 1; }
+  50% { transform: translateY(-2px) scaleY(1.3); opacity: 0.8; }
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -18,8 +18,8 @@ export default function Hero() {
       {/* Animated Background Elements */}
       <div className="absolute inset-0">
         <div className="absolute top-20 left-10 w-72 h-72 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
-        <div className="absolute bottom-20 right-10 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl animate-pulse delay-1000"></div>
-        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-gradient-to-r from-blue-500/5 to-purple-500/5 rounded-full blur-3xl"></div>
+        <div className="absolute bottom-20 right-10 w-96 h-96 bg-orange-500/10 rounded-full blur-3xl animate-pulse delay-1000"></div>
+        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-gradient-to-r from-blue-500/5 to-orange-500/5 rounded-full blur-3xl"></div>
       </div>
 
       {/* Floating Icons */}
@@ -39,7 +39,7 @@ export default function Hero() {
             ease: "easeInOut",
           }}
           className={`absolute hidden lg:block ${
-            index % 2 === 0 ? 'text-blue-400' : 'text-purple-400'
+            index % 2 === 0 ? 'text-blue-400' : 'text-orange-400'
           }`}
           style={{
             left: `${15 + (index * 15)}%`,
@@ -50,7 +50,7 @@ export default function Hero() {
         </motion.div>
       ))}
 
-      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-32 pb-16">
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-12">
         <div className="text-center">
           {/* Main Heading */}
           <motion.div
@@ -59,8 +59,8 @@ export default function Hero() {
             transition={{ duration: 0.8 }}
             className="mb-8"
           >
-            <motion.h1 
-              className="text-4xl md:text-6xl lg:text-7xl font-lexend font-black text-transparent bg-clip-text bg-gradient-to-r from-white via-blue-200 to-purple-200 mb-6 leading-tight"
+            <motion.h1
+              className="text-3xl md:text-5xl lg:text-6xl font-lexend font-black text-transparent bg-clip-text bg-gradient-to-r from-white via-blue-200 to-orange-200 mb-6 leading-tight tracking-tight"
               initial={{ scale: 0.9 }}
               animate={{ scale: 1 }}
               transition={{ duration: 0.8, delay: 0.2 }}
@@ -74,8 +74,8 @@ export default function Hero() {
               transition={{ duration: 0.8, delay: 0.5 }}
               className="relative"
             >
-              <h1 className="text-4xl md:text-6xl lg:text-7xl font-lexend font-black text-transparent bg-clip-text bg-gradient-to-r from-red-400 via-pink-400 to-purple-400 mb-8 leading-tight">
-                Fire Your Secretary
+              <h1 className="text-3xl md:text-5xl lg:text-6xl font-lexend font-black text-transparent bg-clip-text bg-gradient-to-r from-red-400 via-orange-400 to-yellow-300 mb-8 leading-tight tracking-tight">
+                <span className="fire-underline">Fire</span> Your Secretary
               </h1>
             </motion.div>
           </motion.div>
@@ -85,7 +85,7 @@ export default function Hero() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.8 }}
-            className="text-xl md:text-2xl text-gray-300 mb-12 max-w-4xl mx-auto leading-relaxed font-lexend"
+            className="text-lg md:text-xl text-gray-300 mb-12 max-w-4xl mx-auto leading-relaxed font-lexend"
           >
             Forge genuine connections—calls, texts, reminders, and answers that feel human.
             <span className="block mt-2 text-blue-400 font-medium">
@@ -103,14 +103,14 @@ export default function Hero() {
             <motion.button
               whileHover={{ scale: 1.05, boxShadow: "0 0 30px rgba(59, 130, 246, 0.5)" }}
               whileTap={{ scale: 0.95 }}
-              className="group relative px-8 py-4 bg-gradient-to-r from-blue-500 to-purple-600 text-white font-bold rounded-full text-lg shadow-2xl overflow-hidden font-lexend"
+              className="group relative px-8 py-4 bg-gradient-to-r from-blue-500 to-orange-600 text-white font-bold rounded-full text-lg shadow-2xl overflow-hidden font-lexend"
             >
               <span className="relative z-10 flex items-center gap-2">
                 <Bot className="w-5 h-5" />
                 Get Your AI Secretary
               </span>
               <motion.div
-                className="absolute inset-0 bg-gradient-to-r from-blue-400 to-purple-500"
+                className="absolute inset-0 bg-gradient-to-r from-blue-400 to-orange-500"
                 initial={{ scale: 0, rotate: 180 }}
                 whileHover={{ scale: 1, rotate: 0 }}
                 transition={{ duration: 0.3 }}


### PR DESCRIPTION
## Summary
- make hero section slightly smaller and more aligned
- drop purple from gradients and replace with orange tones
- add animated underline for the word **Fire**

## Testing
- `npm install`
- `npm run build` *(fails: Failed to fetch font `Lexend`)*

------
https://chatgpt.com/codex/tasks/task_e_685348f076588321978be2ad1110741c