### PR TITLE
Improve hero and animate steps

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -80,3 +80,18 @@
     @apply bg-background text-foreground;
   }
 }
+@layer components {
+  .fire-underline {
+    @apply relative inline-block pb-1;
+  }
+  .fire-underline::after {
+    content: '';
+    @apply absolute left-0 right-0 bottom-0 h-1 rounded-md;
+    background: linear-gradient(to top, #ff914d, transparent);
+    animation: flame 1s infinite ease-in-out;
+  }
+}
+@keyframes flame {
+  0%, 100% { transform: translateY(0) scaleY(1); opacity: 1; }
+  50% { transform: translateY(-2px) scaleY(1.3); opacity: 0.8; }
+}

--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -99,7 +99,7 @@ export default function Features() {
             Superhuman Capabilities
           </h2>
           <p className="text-xl text-gray-300 max-w-3xl mx-auto font-lexend">
-            Your AI Secretary doesn't just manage your schedule—it revolutionizes how you connect, remember, and follow through.
+            Your AI Secretary doesn&apos;t just manage your schedule—it revolutionizes how you connect, remember, and follow through.
           </p>
         </motion.div>
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -14,12 +14,12 @@ export default function Hero() {
   ];
 
   return (
-    <section className="relative min-h-screen bg-gradient-to-br from-[#060A17] via-[#0A0F1F] to-[#1A1B3A] overflow-hidden">
+    <section className="relative min-h-screen bg-gradient-to-br from-[#0B0E15] via-[#0F141A] to-[#161C22] overflow-hidden">
       {/* Animated Background Elements */}
       <div className="absolute inset-0">
         <div className="absolute top-20 left-10 w-72 h-72 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
-        <div className="absolute bottom-20 right-10 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl animate-pulse delay-1000"></div>
-        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-gradient-to-r from-blue-500/5 to-purple-500/5 rounded-full blur-3xl"></div>
+        <div className="absolute bottom-20 right-10 w-96 h-96 bg-blue-500/5 rounded-full blur-3xl animate-pulse delay-1000"></div>
+        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-gradient-to-r from-blue-500/5 to-slate-500/5 rounded-full blur-3xl"></div>
       </div>
 
       {/* Floating Icons */}
@@ -38,9 +38,7 @@ export default function Hero() {
             repeat: Infinity,
             ease: "easeInOut",
           }}
-          className={`absolute hidden lg:block ${
-            index % 2 === 0 ? 'text-blue-400' : 'text-purple-400'
-          }`}
+          className="absolute hidden lg:block text-blue-400"
           style={{
             left: `${15 + (index * 15)}%`,
             top: `${20 + (index * 10)}%`,
@@ -50,7 +48,7 @@ export default function Hero() {
         </motion.div>
       ))}
 
-      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-32 pb-16">
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-12">
         <div className="text-center">
           {/* Main Heading */}
           <motion.div
@@ -59,8 +57,8 @@ export default function Hero() {
             transition={{ duration: 0.8 }}
             className="mb-8"
           >
-            <motion.h1 
-              className="text-4xl md:text-6xl lg:text-7xl font-lexend font-black text-transparent bg-clip-text bg-gradient-to-r from-white via-blue-200 to-purple-200 mb-6 leading-tight"
+            <motion.h1
+              className="text-3xl md:text-5xl lg:text-6xl font-lexend font-black text-transparent bg-clip-text bg-gradient-to-r from-white to-gray-300 mb-6 leading-tight tracking-tight"
               initial={{ scale: 0.9 }}
               animate={{ scale: 1 }}
               transition={{ duration: 0.8, delay: 0.2 }}
@@ -74,8 +72,8 @@ export default function Hero() {
               transition={{ duration: 0.8, delay: 0.5 }}
               className="relative"
             >
-              <h1 className="text-4xl md:text-6xl lg:text-7xl font-lexend font-black text-transparent bg-clip-text bg-gradient-to-r from-red-400 via-pink-400 to-purple-400 mb-8 leading-tight">
-                Fire Your Secretary
+              <h1 className="text-3xl md:text-5xl lg:text-6xl font-lexend font-black text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-500 mb-8 leading-tight tracking-tight">
+                <span className="fire-underline">Fire</span> Your Secretary
               </h1>
             </motion.div>
           </motion.div>
@@ -85,7 +83,7 @@ export default function Hero() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.8 }}
-            className="text-xl md:text-2xl text-gray-300 mb-12 max-w-4xl mx-auto leading-relaxed font-lexend"
+            className="text-lg md:text-xl text-gray-300 mb-12 max-w-4xl mx-auto leading-relaxed font-lexend"
           >
             Forge genuine connections—calls, texts, reminders, and answers that feel human.
             <span className="block mt-2 text-blue-400 font-medium">
@@ -103,14 +101,14 @@ export default function Hero() {
             <motion.button
               whileHover={{ scale: 1.05, boxShadow: "0 0 30px rgba(59, 130, 246, 0.5)" }}
               whileTap={{ scale: 0.95 }}
-              className="group relative px-8 py-4 bg-gradient-to-r from-blue-500 to-purple-600 text-white font-bold rounded-full text-lg shadow-2xl overflow-hidden font-lexend"
+              className="group relative px-8 py-4 bg-gradient-to-r from-blue-600 to-slate-700 text-white font-bold rounded-full text-lg shadow-2xl overflow-hidden font-lexend"
             >
               <span className="relative z-10 flex items-center gap-2">
                 <Bot className="w-5 h-5" />
                 Get Your AI Secretary
               </span>
               <motion.div
-                className="absolute inset-0 bg-gradient-to-r from-blue-400 to-purple-500"
+                className="absolute inset-0 bg-gradient-to-r from-blue-500 to-slate-600"
                 initial={{ scale: 0, rotate: 180 }}
                 whileHover={{ scale: 1, rotate: 0 }}
                 transition={{ duration: 0.3 }}

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -9,33 +9,29 @@ const steps = [
     number: '01',
     icon: Phone,
     title: 'Connect Your Phone',
-    description: 'Get your dedicated AI Secretary phone number. Share it with clients, colleagues, and contacts.',
-    details: ['Instant setup in under 2 minutes', 'Works with any phone system', 'Professional voicemail greeting'],
-    color: 'from-blue-500 to-cyan-500',
+    description:
+      'Grab your dedicated AI Secretary number and share it with your contacts.',
   },
   {
     number: '02',
     icon: Calendar,
     title: 'Sync Your Calendar',
-    description: 'Connect your existing calendar (Google, Outlook, Apple). Your AI Secretary sees your availability in real-time.',
-    details: ['Two-way calendar sync', 'Respects your preferences', 'Handles time zones automatically'],
-    color: 'from-purple-500 to-pink-500',
+    description:
+      'Link Google or Outlook so your availability is always up to date.',
   },
   {
     number: '03',
     icon: Brain,
-    title: 'Train Your Preferences',
-    description: 'Tell your AI Secretary about your meeting preferences, availability, and communication style.',
-    details: ['Natural language setup', 'Learns from every interaction', 'Adapts to your schedule patterns'],
-    color: 'from-green-500 to-emerald-500',
+    title: 'Train Preferences',
+    description:
+      'Teach your AI Secretary how and when you like to meet or respond.',
   },
   {
     number: '04',
     icon: MessageSquare,
     title: 'Start Delegating',
-    description: 'Your AI Secretary handles calls, texts, scheduling, and reminders while you focus on what matters.',
-    details: ['24/7 availability', 'Human-like conversations', 'Seamless handoffs when needed'],
-    color: 'from-orange-500 to-red-500',
+    description:
+      'Let your AI handle calls, texts and reminders while you focus.',
   },
 ];
 
@@ -117,18 +113,18 @@ const CallAnimation = () => {
             whileInView={{ x: 0, opacity: 1 }}
             transition={{ duration: 0.5, delay: 0.5 }}
             viewport={{ once: true }}
-            className="flex items-center gap-4 mb-6 p-4 bg-purple-500/20 rounded-2xl border border-purple-500/30"
+            className="flex items-center gap-4 mb-6 p-4 bg-yellow-500/20 rounded-2xl border border-yellow-500/30"
           >
-            <Brain className="w-8 h-8 text-purple-400" />
+            <Brain className="w-8 h-8 text-yellow-400" />
             <div className="flex-1">
               <p className="text-white font-semibold font-lexend">AI Processing</p>
               <div className="flex items-center gap-2 mt-2">
                 <motion.div
                   animate={{ rotate: 360 }}
                   transition={{ duration: 2, repeat: Infinity, ease: "linear" }}
-                  className="w-4 h-4 border-2 border-purple-400 border-t-transparent rounded-full"
+                  className="w-4 h-4 border-2 border-yellow-400 border-t-transparent rounded-full"
                 />
-                <p className="text-purple-300 text-sm font-lexend">Checking calendar availability...</p>
+                <p className="text-yellow-300 text-sm font-lexend">Checking calendar availability...</p>
               </div>
             </div>
           </motion.div>
@@ -169,7 +165,7 @@ const CallAnimation = () => {
             whileInView={{ pathLength: 1 }}
             transition={{ duration: 2, delay: 0.5 }}
             viewport={{ once: true }}
-            className="absolute left-8 top-16 bottom-16 w-0.5 bg-gradient-to-b from-blue-400 via-purple-400 via-green-400 to-orange-400 opacity-50"
+            className="absolute left-8 top-16 bottom-16 w-0.5 bg-gradient-to-b from-blue-400 via-yellow-400 via-green-400 to-orange-400 opacity-50"
           />
         </div>
       </div>
@@ -194,7 +190,7 @@ export default function HowItWorks() {
           viewport={{ once: true }}
           className="text-center mb-20"
         >
-          <h2 className="text-5xl md:text-6xl font-lexend font-bold text-transparent bg-clip-text bg-gradient-to-r from-white to-purple-200 mb-6">
+          <h2 className="text-5xl md:text-6xl font-lexend font-bold text-transparent bg-clip-text bg-gradient-to-r from-white to-blue-200 mb-6">
             How It Works
           </h2>
           <p className="text-xl text-gray-300 max-w-3xl mx-auto font-lexend">
@@ -206,65 +202,33 @@ export default function HowItWorks() {
         <CallAnimation />
 
         {/* Steps */}
-        <div ref={ref} className="mb-20">
+        <div ref={ref} className="grid grid-cols-1 md:grid-cols-4 gap-8 mb-20">
           {steps.map((step, index) => (
             <motion.div
               key={index}
-              initial={{ opacity: 0, x: index % 2 === 0 ? -50 : 50 }}
-              whileInView={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.8, delay: index * 0.2 }}
+              initial={{ opacity: 0, y: 40 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8, delay: index * 0.1 }}
               viewport={{ once: true }}
-              className={`flex flex-col lg:flex-row items-center gap-12 mb-16 ${
-                index % 2 === 1 ? 'lg:flex-row-reverse' : ''
-              }`}
+              whileHover={{ scale: 1.05 }}
+              className="flex flex-col items-center text-center space-y-4 bg-white/5 backdrop-blur-md p-6 rounded-2xl border border-white/10 hover:border-blue-500/40"
             >
-              {/* Content */}
-              <div className="flex-1 space-y-6">
-                <div className="flex items-center gap-4">
-                  <span className={`text-6xl font-black text-transparent bg-clip-text bg-gradient-to-r ${step.color} font-lexend`}>
-                    {step.number}
-                  </span>
-                  <div className={`p-4 rounded-2xl bg-gradient-to-r ${step.color}`}>
-                    <step.icon className="w-8 h-8 text-white" />
-                  </div>
-                </div>
-                
-                <h3 className="text-3xl md:text-4xl font-bold text-white font-lexend">{step.title}</h3>
-                <p className="text-xl text-gray-300 leading-relaxed font-lexend">{step.description}</p>
-                
-                <ul className="space-y-3">
-                  {step.details.map((detail, detailIndex) => (
-                    <li key={detailIndex} className="flex items-center gap-3 text-gray-400 font-lexend">
-                      <div className={`w-2 h-2 rounded-full bg-gradient-to-r ${step.color}`} />
-                      {detail}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-
-              {/* Visual */}
               <motion.div
-                whileHover={{ scale: 1.05, rotateY: 5 }}
-                className="flex-1 relative"
+                animate={{ y: [0, -6, 0] }}
+                transition={{ duration: 2, repeat: Infinity }}
+                className="w-12 h-12 flex items-center justify-center rounded-full bg-blue-500/20"
               >
-                <div className="relative bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-xl rounded-3xl p-8 border border-white/10 aspect-square flex items-center justify-center">
-                  <div className={`w-32 h-32 rounded-full bg-gradient-to-r ${step.color} flex items-center justify-center`}>
-                    <step.icon className="w-16 h-16 text-white" />
-                  </div>
-                  
-                  {/* Animated rings */}
-                  <motion.div
-                    animate={{ scale: [1, 1.2, 1], opacity: [0.5, 0, 0.5] }}
-                    transition={{ duration: 2, repeat: Infinity }}
-                    className={`absolute inset-8 border-2 border-current rounded-full bg-gradient-to-r ${step.color} bg-clip-text text-transparent`}
-                  />
-                  <motion.div
-                    animate={{ scale: [1, 1.4, 1], opacity: [0.3, 0, 0.3] }}
-                    transition={{ duration: 2, repeat: Infinity, delay: 0.5 }}
-                    className={`absolute inset-4 border border-current rounded-full bg-gradient-to-r ${step.color} bg-clip-text text-transparent`}
-                  />
-                </div>
+                <step.icon className="w-6 h-6 text-blue-300" />
               </motion.div>
+              <div className="text-3xl font-extrabold text-blue-300 font-lexend">
+                {step.number}
+              </div>
+              <h3 className="text-lg font-semibold text-white font-lexend">
+                {step.title}
+              </h3>
+              <p className="text-gray-400 text-sm font-lexend">
+                {step.description}
+              </p>
             </motion.div>
           ))}
         </div>
@@ -315,7 +279,7 @@ export default function HowItWorks() {
           whileInView={{ opacity: 1, scale: 1 }}
           transition={{ duration: 0.8 }}
           viewport={{ once: true }}
-          className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-indigo-600/20 to-purple-600/20 border border-white/10 p-8 md:p-12 text-center"
+          className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-blue-600/20 to-indigo-600/20 border border-white/10 p-8 md:p-12 text-center"
         >
           <h3 className="text-3xl md:text-4xl font-bold text-white mb-4 font-lexend">
             See It in Action
@@ -335,7 +299,7 @@ export default function HowItWorks() {
           
           {/* Background decoration */}
           <div className="absolute top-4 right-4 w-32 h-32 bg-blue-500/10 rounded-full blur-2xl"></div>
-          <div className="absolute bottom-4 left-4 w-40 h-40 bg-purple-500/10 rounded-full blur-2xl"></div>
+          <div className="absolute bottom-4 left-4 w-40 h-40 bg-blue-500/10 rounded-full blur-2xl"></div>
         </motion.div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- tweak How It Works styling and animation
- keep cool orange/blue palette and remove purple
- bounce step icons on hover

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Lexend`)*

------
https://chatgpt.com/codex/tasks/task_e_685348f076588321978be2ad1110741c